### PR TITLE
Streamline webhook message sending method

### DIFF
--- a/src/main/java/com/webhook/root/controller/WebhookMessageController.java
+++ b/src/main/java/com/webhook/root/controller/WebhookMessageController.java
@@ -3,31 +3,47 @@ package com.webhook.root.controller;
 import com.webhook.root.message.WebhookMessageReceiver;
 import com.webhook.root.message.WebhookMessageRequest;
 import com.webhook.root.message.WebhookMessageService;
+import com.webhook.root.model.Endpoint;
 import com.webhook.root.model.WebhookMessage;
+import com.webhook.root.repository.EndpointRepository;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/webhooks")
+@RequestMapping("/")
 public class WebhookMessageController {
 
     private final WebhookMessageService webhookMessageService;
 	private final WebhookMessageReceiver webhookMessageReceiver;
+	private final EndpointRepository endpointRepository;
 
-    public WebhookMessageController(WebhookMessageService webhookMessageService, WebhookMessageReceiver webhookMessageReceiver) {
+    public WebhookMessageController(WebhookMessageService webhookMessageService, WebhookMessageReceiver webhookMessageReceiver, EndpointRepository endpointRepository) {
         this.webhookMessageService = webhookMessageService;
 		this.webhookMessageReceiver = webhookMessageReceiver;
+		this.endpointRepository = endpointRepository;
     }
 
-    @GetMapping
+    @GetMapping("/webhooks")
     public List<WebhookMessage> getAllWebhookMessages() {
         return this.webhookMessageService.getAllWebhookMessages();
     }
 
-    @PostMapping
+    @PostMapping("/webhooks")
     public WebhookMessage createWebhookMessage(@RequestBody WebhookMessageRequest webhookMessageRequest) {
         return this.webhookMessageReceiver.receiveWebhookMessage(webhookMessageRequest);
     }
+
+	@PostMapping("/{endpoint_id}/message")
+	public WebhookMessage sendWebhookMessage(@PathVariable UUID endpoint_id, @RequestBody WebhookMessageRequest messageRequest) throws Exception {
+		// check if endpoint exists and is healthy
+		if (!endpointRepository.existsById(endpoint_id)) throw new Exception("Endpoint does not exist");
+
+		Endpoint endpoint = endpointRepository.findById(endpoint_id).get();
+		if (!endpoint.getEnabled()) throw new Exception("Endpoint not enabled");
+
+		return this.webhookMessageReceiver.receiveWebhookMessage(messageRequest);
+	}
 }

--- a/src/main/java/com/webhook/root/controller/WebhookMessageController.java
+++ b/src/main/java/com/webhook/root/controller/WebhookMessageController.java
@@ -4,12 +4,16 @@ import com.webhook.root.message.WebhookMessageReceiver;
 import com.webhook.root.message.WebhookMessageRequest;
 import com.webhook.root.message.WebhookMessageService;
 import com.webhook.root.model.Endpoint;
+import com.webhook.root.model.PublisherAccount;
 import com.webhook.root.model.WebhookMessage;
 import com.webhook.root.repository.EndpointRepository;
+import com.webhook.root.repository.PublisherAccountRepository;
 
 import java.util.List;
 import java.util.UUID;
 
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,11 +23,13 @@ public class WebhookMessageController {
     private final WebhookMessageService webhookMessageService;
 	private final WebhookMessageReceiver webhookMessageReceiver;
 	private final EndpointRepository endpointRepository;
+	private final PublisherAccountRepository publisherRepository;
 
-    public WebhookMessageController(WebhookMessageService webhookMessageService, WebhookMessageReceiver webhookMessageReceiver, EndpointRepository endpointRepository) {
+    public WebhookMessageController(WebhookMessageService webhookMessageService, WebhookMessageReceiver webhookMessageReceiver, EndpointRepository endpointRepository, PublisherAccountRepository publisherRepository) {
         this.webhookMessageService = webhookMessageService;
 		this.webhookMessageReceiver = webhookMessageReceiver;
 		this.endpointRepository = endpointRepository;
+		this.publisherRepository = publisherRepository;
     }
 
     @GetMapping("/webhooks")
@@ -31,19 +37,22 @@ public class WebhookMessageController {
         return this.webhookMessageService.getAllWebhookMessages();
     }
 
-    @PostMapping("/webhooks")
-    public WebhookMessage createWebhookMessage(@RequestBody WebhookMessageRequest webhookMessageRequest) {
-        return this.webhookMessageReceiver.receiveWebhookMessage(webhookMessageRequest);
-    }
-
 	@PostMapping("/{endpoint_id}/message")
-	public WebhookMessage sendWebhookMessage(@PathVariable UUID endpoint_id, @RequestBody WebhookMessageRequest messageRequest) throws Exception {
+	public WebhookMessage sendWebhookMessage(@PathVariable UUID endpoint_id, @RequestBody WebhookMessageRequest request) throws Exception {
 		// check if endpoint exists and is healthy
 		if (!endpointRepository.existsById(endpoint_id)) throw new Exception("Endpoint does not exist");
 
+		// find endpoint from path variable
 		Endpoint endpoint = endpointRepository.findById(endpoint_id).get();
 		if (!endpoint.getEnabled()) throw new Exception("Endpoint not enabled");
 
-		return this.webhookMessageReceiver.receiveWebhookMessage(messageRequest);
+		// get publisher from security context
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		String username = auth.getName();
+		PublisherAccount publisher = publisherRepository.findByUsername(username);
+
+		WebhookMessage message = new WebhookMessage(endpoint, publisher, request.getHeaders(), request.getPayload(), request.getEventType());
+
+		return this.webhookMessageReceiver.receiveWebhookMessage(message);
 	}
 }

--- a/src/main/java/com/webhook/root/message/WebhookMessageReceiver.java
+++ b/src/main/java/com/webhook/root/message/WebhookMessageReceiver.java
@@ -4,8 +4,6 @@ import org.springframework.stereotype.Service;
 
 import com.webhook.root.endpoint.EndpointService;
 import com.webhook.root.kafka.KafkaProducer;
-import com.webhook.root.model.Endpoint;
-import com.webhook.root.model.PublisherAccount;
 import com.webhook.root.model.WebhookMessage;
 import com.webhook.root.publisher.PublisherAccountService;
 import com.webhook.root.repository.WebhookMessageRepository;
@@ -15,8 +13,6 @@ public class WebhookMessageReceiver {
 
 	private final WebhookMessageRepository webhookMessageRepository;
 	private final KafkaProducer producerService;
-	private final PublisherAccountService accountService;
-	private final EndpointService endpointService;
 
 	public WebhookMessageReceiver(WebhookMessageRepository webhookMessageRepository, 
 								KafkaProducer producerService, 
@@ -24,15 +20,10 @@ public class WebhookMessageReceiver {
 								EndpointService endpointService) {
         this.webhookMessageRepository = webhookMessageRepository;
 		this.producerService = producerService;
-		this.endpointService = endpointService;
-		this.accountService = accountService;
     }
 
-	public WebhookMessage receiveWebhookMessage(WebhookMessageRequest request) {
-		Endpoint endpoint = endpointService.findById(request.getEndpointId()).get();
-		PublisherAccount publisherAccount = accountService.findById(request.getPublisherAccountId());
+	public WebhookMessage receiveWebhookMessage(WebhookMessage webhookMessage) {
 
-		WebhookMessage webhookMessage = new WebhookMessage(endpoint, publisherAccount, request.getHeaders(), request.getPayload(), request.getEventType());
 		// save to DB
 		webhookMessageRepository.save(webhookMessage);
 

--- a/src/main/java/com/webhook/root/message/WebhookMessageRequest.java
+++ b/src/main/java/com/webhook/root/message/WebhookMessageRequest.java
@@ -1,30 +1,11 @@
 package com.webhook.root.message;
 
 import java.util.Map;
-import java.util.UUID;
 
 public class WebhookMessageRequest {
-	private UUID endpointId;
-	private UUID publisherAccountId;
 	private Map<String, Object> headers;
 	private Map<String, Object> payload;
 	private String eventType;
-
-	public UUID getEndpointId() {
-		return endpointId;
-	}
-
-	public void setEndpointId(UUID endpointId) {
-		this.endpointId = endpointId;
-	}
-
-	public UUID getPublisherAccountId() {
-		return publisherAccountId;
-	}
-
-	public void setPublisherAccountId(UUID publisherAccountId) {
-		this.publisherAccountId = publisherAccountId;
-	}
 
 	public Map<String, Object> getHeaders() {
 		return headers;

--- a/src/main/java/com/webhook/root/security/SecurityConfig.java
+++ b/src/main/java/com/webhook/root/security/SecurityConfig.java
@@ -12,6 +12,9 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.context.DelegatingSecurityContextRepository;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.RequestAttributeSecurityContextRepository;
 
 @Configuration
 @EnableWebSecurity
@@ -46,15 +49,21 @@ public class SecurityConfig {
         http
 			.csrf(csrf -> csrf.disable())
 			.cors(cors -> cors.disable())
-			.exceptionHandling(exception -> 
-					exception.authenticationEntryPoint(unauthorisedHandler)
+			.exceptionHandling(exception -> exception
+				.authenticationEntryPoint(unauthorisedHandler)
 			)
-			.sessionManagement(session -> 
-					session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			.sessionManagement(session -> session
+				.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			)
-			.authorizeHttpRequests(auth -> 
-					auth.requestMatchers("/auth/**", "/test/all", "/**").permitAll()
-					.anyRequest().authenticated()
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/auth/**", "/test/all", "/**").permitAll()
+				.anyRequest().authenticated()
+			)
+			.securityContext(context -> context
+				.securityContextRepository(new DelegatingSecurityContextRepository(
+					new RequestAttributeSecurityContextRepository(),
+					new HttpSessionSecurityContextRepository()
+				))
 			);
 
 		http.addFilterBefore(authenticationJwtTokenFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/webhook/root/security/SecurityConfig.java
+++ b/src/main/java/com/webhook/root/security/SecurityConfig.java
@@ -56,7 +56,7 @@ public class SecurityConfig {
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			)
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/auth/**", "/test/all", "/**").permitAll()
+				.requestMatchers("/auth/**", "/test/all").permitAll()
 				.anyRequest().authenticated()
 			)
 			.securityContext(context -> context


### PR DESCRIPTION
I have modified the WebhookMessageController POST method to pull the endpoint ID from the path and find the associated Endpoint. Furthermore, the publisher account ID is pulled from the logged in user in the security context.
The result is a more streamlined Webhook Message Request body to be submitted by the user; they do not need to know their ID.